### PR TITLE
Fix tree growth/sand issue (typo) and sand<=>sandstone doubling

### DIFF
--- a/mods/default/crafting.lua
+++ b/mods/default/crafting.lua
@@ -323,7 +323,7 @@ minetest.register_craft({
 })
 
 minetest.register_craft({
-	output = 'default:sandstone 2',
+	output = 'default:sandstone',
 	recipe = {
 		{'group:sand', 'group:sand'},
 		{'group:sand', 'group:sand'},

--- a/mods/default/crafting.lua
+++ b/mods/default/crafting.lua
@@ -323,7 +323,7 @@ minetest.register_craft({
 })
 
 minetest.register_craft({
-	output = 'default:sandstone',
+	output = 'default:sandstone 2',
 	recipe = {
 		{'group:sand', 'group:sand'},
 		{'group:sand', 'group:sand'},
@@ -331,7 +331,7 @@ minetest.register_craft({
 })
 
 minetest.register_craft({
-	output = 'default:sand 4',
+	output = 'default:sand 2',
 	recipe = {
 		{'default:sandstone'},
 	}

--- a/mods/default/crafting.lua
+++ b/mods/default/crafting.lua
@@ -322,6 +322,7 @@ minetest.register_craft({
 	}
 })
 
+-- Making sandstone easier to craft. 4 Sand --> 2 Sandstone, so later 1 Sandstone --> 2 Sand
 minetest.register_craft({
 	output = 'default:sandstone 2',
 	recipe = {

--- a/mods/lottplants/functions.lua
+++ b/mods/lottplants/functions.lua
@@ -613,7 +613,7 @@ local function can_grow(pos)
 		return false
 	end
 	local is_soil = minetest.get_item_group(node.name, "soil")
-	local is_soil = minetest.get_item_group(node.name, "sand")
+	local is_sand = minetest.get_item_group(node.name, "sand")
 	local is_stone = minetest.get_item_group(node.name, "stone")
 	if is_soil == 0 and is_sand == 0 and is_stone == 0 then
 		return false


### PR DESCRIPTION
Noticed a couple "sand" issues. The first is merely a typo in your last update, and the second has to do with back-and-forth conversion of sand/sandstone resulting in doubling of said items.